### PR TITLE
Fix typo

### DIFF
--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -2,7 +2,7 @@
 layout: post
 title: Probability Review
 ---
-We will go through a review of probability concepts over here, all of review the material have been adapted from [CS229 Probability Notes](http://cs229.stanford.edu/section/cs229-prob.pdf).
+We will go through a review of probability concepts over here, all of the review materials have been adapted from [CS229 Probability Notes](http://cs229.stanford.edu/section/cs229-prob.pdf).
 
 # 1. Elements of probability
 In order to define a probability on a set we need a few basic elements,


### PR DESCRIPTION
I think it should be 

```
... all of the review materials ...
```

instead of 

```
... all of review the material ...
```