### PR TITLE
Fixed typo in section on reparametrization trick

### DIFF
--- a/extras/vae/index.md
+++ b/extras/vae/index.md
@@ -153,7 +153,7 @@ where $$\epsilon \sim \mathcal{N}(0,1)$$. It is easy to check that the two ways 
 
 The biggest advantage of this approach is that we many now write the gradient of an expectation with respect to $$q(z)$$ (for any $$f$$) as
 {%math%}
- \nabla_\phi \mathbb{E}_{z \sim q(z\mid x)}\left[ f(x,z) \right] = \nabla_\phi \mathbb{E}_{\epsilon \sim p(\epsilon)}\left[ f(x,g(z,\epsilon)) \right] = \mathbb{E}_{\epsilon \sim p(\epsilon)}\left[ \nabla_\phi f(x,g(z,\epsilon)) \right].
+ \nabla_\phi \mathbb{E}_{z \sim q(z\mid x)}\left[ f(x,z) \right] = \nabla_\phi \mathbb{E}_{\epsilon \sim p(\epsilon)}\left[ f(x,g(\epsilon, x)) \right] = \mathbb{E}_{\epsilon \sim p(\epsilon)}\left[ \nabla_\phi f(x,g(\epsilon, x)) \right].
 {%endmath%}
 The gradient is now inside the expectation and we may use Monte Carlo to get an estimate of the right-hand term.
 This approach will have a much lower variance{%sidenote 1 'For more details as to why, have a look at the appendix of the paper by [Rezende et al.](https://arxiv.org/pdf/1401.4082.pdf)'%} than the score function estimator, and will enable us to learn models that we otherwise couldn't learn.


### PR DESCRIPTION
I believe this is a typo.

From my understanding, we approximate sampling z from a distribution x through an intermediate transformation that takes an epsilon + distribution and outputs a z.

Thus, it should be g(\epsilon, x) not g(z, \epsilon)(also swapped order of parameters around to preserve notation of previous definition).

Credit to @isaykatsman for originally bringing up the typo.