### PR TITLE
Fix the math equation format for probability review

### DIFF
--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -51,10 +51,6 @@ P(S_1 \cap S_2) = P(S_1) P(S_2 | S_1)
 
 In general, it is derived by applying the definition of conditional independence multiple times, as in the following example
 
-\begin{equation}
-P(S_1 \cap S_2 \cap S_3 \cap S_4) =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
-\end{equation}
-
 {% math %}
 \begin{aligned}
 P(S_1 \cap S_2 \cap S_3 \cap S_4) & =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
@@ -173,12 +169,14 @@ The variance of a random variable $$X$$ is a measure of how concentrated the dis
 
 Using the **properties** in the previous section, we can derive an alternate expression for the variance:
 
-\begin{equation}
+{% math %}
+\begin{aligned}
 E[(X − E[X])^2] \\
 = E[X^2 − 2E[X]X + E[X]^2] \\
 = E[X^2] − 2E[X]E[X] + E[X]^2 \\
 = E[X^2] − E[X]^2,
-\end{equation}
+\end{aligned}
+{% endmath %}
 
 where the second equality follows from linearity of expectations and the fact that $$E[X]$$ is actually a
 constant with respect to the outer expectation.
@@ -204,8 +202,9 @@ E[g(X)] = \sum_{x \in Val(X)} \mathbf{1}\{x \in A\}P_X(x)dx = \sum_{x \in A} P_X
 \end{equation}
 
 ### **Continuous case**:
+
 \begin{equation}
-E[g(X)] = \int^{\infty}_{-\infty} \mathbf{1}\{x \in A\} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
+E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1}\{x \in A\} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
 \end{equation}
 
 
@@ -405,12 +404,14 @@ Cov[X, Y] = E[(X − E[X])(Y − E[Y])]
 {% endmath %}
 
 Using an argument similar to that for variance, we can rewrite this as,
+{% math %}
 \begin{aligned}
 Cov[X, Y] & = E[(X − E[X])(Y − E[Y])] \\
 & = E[XY − XE[Y] − Y E[X] + E[X]E[Y]] \\
 & = E[XY] − E[X]E[Y] − E[Y]E[X] + E[X]E[Y] \\
 & = E[XY] − E[X]E[Y].
 \end{aligned}
+{% endmath %}
 
 Here, the key step in showing the equality of the two forms of covariance is in the third equality, where we use the fact that $$E[X]$$ and $$E[Y]$$ are actually constants which can be pulled out of the expectation. When $$Cov[X, Y] = 0$$, we say that $$X$$ and $$Y$$ are uncorrelated.
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -55,13 +55,13 @@ In general, it is derived by applying the definition of conditional independence
 P(S_1 \cap S_2 \cap S_3 \cap S_4) =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{equation}
 
-$$
+{% math %}
 \begin{aligned}
 P(S_1 \cap S_2 \cap S_3 \cap S_4) & =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
                                   & = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
                                   & = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{aligned}
-$$
+{% math %}
 
 ## 1.3 Independence
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -31,7 +31,9 @@ These three **properties** are called the **Axioms of Probability**.
 ## 1.1 Conditional probability
 
 Let $$B$$ be an event with non-zero probability. The conditional probability of any event $$A$$ given $$B$$ is defined as
-$$ P(A \mid B) = \frac {P(A \cap B)}{P(B)}$$.
+\begin{equation}
+P(A \mid B) = \frac {P(A \cap B)}{P(B)}.
+\end{equation}
 In other words, $$P(A \mid B)$$ is the probability measure of the event $$A$$ after observing the occurrence of
 event $$B$$. 
 
@@ -202,13 +204,13 @@ constant with respect to the outer expectation.
 ### **Discrete case**:
 
 \begin{equation}
-E[g(X)] = \sum_{x \in Val(X)} \mathbf{1}\{x \in A\}P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
+E[g(X)] = \sum_{x \in Val(X)} \mathbf{1} \{x \in A \} P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
 \end{equation}
 
 ### **Continuous case**:
 
 \begin{equation}
-E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1}\{x \in A\} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
+E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1} \{x \in A \} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
 \end{equation}
 
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -31,7 +31,9 @@ These three **properties** are called the **Axioms of Probability**.
 ## 1.1 Conditional probability
 
 Let $$B$$ be an event with non-zero probability. The conditional probability of any event $$A$$ given $$B$$ is defined as
-$$ P(A \mid B) = \frac {P(A \cap B)}{P(B)}$$.
+\begin{equation} 
+P(A \mid B) = \frac {P(A \cap B)}{P(B)}.
+\end{equation}
 In other words, $$P(A \mid B)$$ is the probability measure of the event $$A$$ after observing the occurrence of
 event $$B$$. 
 
@@ -41,8 +43,8 @@ Let $$S_1, \cdots, S_k$$ be events, $$P(S_i) >0$$. Then
 
 {% math %}
 \begin{aligned}
-  & P(S_1 \cap S_2 \cap \cdots \cap S_k) \\
-= & P(S_1) P(S_2 | S_1) P(S_3 | S_2 \cap S_1 ) \cdots  P(S_k | S_1 \cap S_2 \cap \cdots S_{k-1})
+&   & P(S_1 \cap S_2 \cap \cdots \cap S_k) \\
+& = & P(S_1) P(S_2 | S_1) P(S_3 | S_2 \cap S_1 ) \cdots  P(S_k | S_1 \cap S_2 \cap \cdots S_{k-1})
 \end{aligned}
 {% endmath %}
 
@@ -56,10 +58,10 @@ In general, it is derived by applying the definition of conditional independence
 
 {% math %}
 \begin{aligned}
-  & P(S_1 \cap S_2 \cap S_3 \cap S_4) \\
-= & P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
-= & P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
-= & P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
+&   & P(S_1 \cap S_2 \cap S_3 \cap S_4) \\
+& = & P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+& = & P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+& = & P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{aligned}
 {% endmath %}
 
@@ -202,13 +204,13 @@ constant with respect to the outer expectation.
 ### **Discrete case**:
 
 \begin{equation}
-E[g(X)] = \sum_{x \in Val(X)} \mathbf{1}\{x \in A\}P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
+E[g(X)] = \sum_{x \in Val(X)} \mathbf{1}{x \in A} P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
 \end{equation}
 
 ### **Continuous case**:
 
 \begin{equation}
-E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1}\{x \in A\} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
+E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1}{x \in A} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
 \end{equation}
 
 
@@ -357,8 +359,8 @@ The chain rule we derived earlier for events can be applied to random variables 
 
 {% math %}
 \begin{aligned}
-  & p_{X_1, \cdots X_n} (x_1, \cdots, x_n) \\
-= & p_{X_1} (x_1) p_{X_2 \mid X_1} (x_2 \mid x_1) \cdots p_{X_n \mid X_1, \cdots, X_{n-1}} (x_n \mid x_1, \cdots, x_{n-1})
+&   & p_{X_1, \cdots X_n} (x_1, \cdots, x_n) \\
+& = & p_{X_1} (x_1) p_{X_2 \mid X_1} (x_2 \mid x_1) \cdots p_{X_n \mid X_1, \cdots, X_{n-1}} (x_n \mid x_1, \cdots, x_{n-1})
 \end{aligned}
 {% endmath %}
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -61,7 +61,7 @@ P(S_1 \cap S_2 \cap S_3 \cap S_4) & =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \
                                   & = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
                                   & = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{aligned}
-{% math %}
+{% endmath %}
 
 ## 1.3 Independence
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -55,11 +55,13 @@ In general, it is derived by applying the definition of conditional independence
 P(S_1 \cap S_2 \cap S_3 \cap S_4) =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{equation}
 
-\begin{eqnarray}
+$$
+\begin{aligned}
 P(S_1 \cap S_2 \cap S_3 \cap S_4) & =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
                                   & = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
                                   & = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
-\end{eqnarray}
+\end{aligned}
+$$
 
 ## 1.3 Independence
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -203,15 +203,15 @@ constant with respect to the outer expectation.
 
 ### **Discrete case**:
 
-\begin{equation}
+{% math %}
 E[g(X)] = \sum_{x \in Val(X)} \mathbf{1} \{x \in A \} P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
-\end{equation}
+{% math %}
 
 ### **Continuous case**:
 
-\begin{equation}
+{% math %}
 E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1} \{x \in A \} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
-\end{equation}
+{% math %}
 
 
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -205,13 +205,13 @@ constant with respect to the outer expectation.
 
 {% math %}
 E[g(X)] = \sum_{x \in Val(X)} \mathbf{1} \{x \in A \} P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
-{% math %}
+{% endmath %}
 
 ### **Continuous case**:
 
 {% math %}
 E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1} \{x \in A \} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
-{% math %}
+{% endmath %}
 
 
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -39,9 +39,12 @@ event $$B$$.
 
 Let $$S_1, \cdots, S_k$$ be events, $$P(S_i) >0$$. Then
 
-\begin{equation}
-P(S_1 \cap S_2 \cap \cdots \cap S_k) = P(S_1) P(S_2 | S_1) P(S_3 | S_2 \cap S_1 ) \cdots  P(S_k | S_1 \cap S_2 \cap \cdots S_{k-1})
-\end{equation}
+{% math %}
+\begin{aligned}
+  & P(S_1 \cap S_2 \cap \cdots \cap S_k) \\
+= & P(S_1) P(S_2 | S_1) P(S_3 | S_2 \cap S_1 ) \cdots  P(S_k | S_1 \cap S_2 \cap \cdots S_{k-1})
+\end{aligned}
+{% endmath %}
 
 Note that for $$k=2$$ events, this is just the definition of conditional probability
 
@@ -53,9 +56,10 @@ In general, it is derived by applying the definition of conditional independence
 
 {% math %}
 \begin{aligned}
-P(S_1 \cap S_2 \cap S_3 \cap S_4) & =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
-                                  & = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
-                                  & = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
+  & P(S_1 \cap S_2 \cap S_3 \cap S_4) \\
+= & P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+= & P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+= & P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{aligned}
 {% endmath %}
 
@@ -171,10 +175,10 @@ Using the **properties** in the previous section, we can derive an alternate exp
 
 {% math %}
 \begin{aligned}
-E[(X − E[X])^2] \\
-= E[X^2 − 2E[X]X + E[X]^2] \\
-= E[X^2] − 2E[X]E[X] + E[X]^2 \\
-= E[X^2] − E[X]^2,
+  & E[(X − E[X])^2] \\
+= & E[X^2 − 2E[X]X + E[X]^2] \\
+= & E[X^2] − 2E[X]E[X] + E[X]^2 \\
+= & E[X^2] − E[X]^2,
 \end{aligned}
 {% endmath %}
 
@@ -351,9 +355,12 @@ provided $$f_X(x) \neq 0$$.
 
 The chain rule we derived earlier for events can be applied to random variables as follows:
 
-\begin{equation}
-p_{X_1, \cdots X_n} (x_1, \cdots, x_n) = p_{X_1} (x_1) p_{X_2 \mid X_1} (x_2 \mid x_1) \cdots p_{X_n \mid X_1, \cdots, X_{n-1}} (x_n \mid x_1, \cdots, x_{n-1})
-\end{equation}
+{% math %}
+\begin{aligned}
+  & p_{X_1, \cdots X_n} (x_1, \cdots, x_n) \\
+= & p_{X_1} (x_1) p_{X_2 \mid X_1} (x_2 \mid x_1) \cdots p_{X_n \mid X_1, \cdots, X_{n-1}} (x_n \mid x_1, \cdots, x_{n-1})
+\end{aligned}
+{% endmath %}
 
 ## 3.6 Bayes’s rule
 

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -55,6 +55,12 @@ In general, it is derived by applying the definition of conditional independence
 P(S_1 \cap S_2 \cap S_3 \cap S_4) =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{equation}
 
+\begin{eqnarray}
+P(S_1 \cap S_2 \cap S_3 \cap S_4) & =  P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+                                  & = P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+                                  & = P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
+\end{eqnarray}
+
 ## 1.3 Independence
 
 Two events are called independent if and only if $$P(A \cap B) = P(A)P(B)$$ (or equivalently,

--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -31,9 +31,7 @@ These three **properties** are called the **Axioms of Probability**.
 ## 1.1 Conditional probability
 
 Let $$B$$ be an event with non-zero probability. The conditional probability of any event $$A$$ given $$B$$ is defined as
-\begin{equation} 
-P(A \mid B) = \frac {P(A \cap B)}{P(B)}.
-\end{equation}
+$$ P(A \mid B) = \frac {P(A \cap B)}{P(B)}$$.
 In other words, $$P(A \mid B)$$ is the probability measure of the event $$A$$ after observing the occurrence of
 event $$B$$. 
 
@@ -43,8 +41,8 @@ Let $$S_1, \cdots, S_k$$ be events, $$P(S_i) >0$$. Then
 
 {% math %}
 \begin{aligned}
-&   & P(S_1 \cap S_2 \cap \cdots \cap S_k) \\
-& = & P(S_1) P(S_2 | S_1) P(S_3 | S_2 \cap S_1 ) \cdots  P(S_k | S_1 \cap S_2 \cap \cdots S_{k-1})
+  & P(S_1 \cap S_2 \cap \cdots \cap S_k) \\
+= & P(S_1) P(S_2 | S_1) P(S_3 | S_2 \cap S_1 ) \cdots  P(S_k | S_1 \cap S_2 \cap \cdots S_{k-1})
 \end{aligned}
 {% endmath %}
 
@@ -58,10 +56,10 @@ In general, it is derived by applying the definition of conditional independence
 
 {% math %}
 \begin{aligned}
-&   & P(S_1 \cap S_2 \cap S_3 \cap S_4) \\
-& = & P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
-& = & P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
-& = & P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
+  & P(S_1 \cap S_2 \cap S_3 \cap S_4) \\
+= & P(S_1 \cap S_2 \cap S_3) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+= & P(S_1 \cap S_2) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3) \\
+= & P(S_1) P(S_2 \mid S_1) P(S_3 \mid S_1 \cap S_2) P(S_4 \mid S_1 \cap S_2 \cap S_3)
 \end{aligned}
 {% endmath %}
 
@@ -204,13 +202,13 @@ constant with respect to the outer expectation.
 ### **Discrete case**:
 
 \begin{equation}
-E[g(X)] = \sum_{x \in Val(X)} \mathbf{1}{x \in A} P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
+E[g(X)] = \sum_{x \in Val(X)} \mathbf{1}\{x \in A\}P_X(x)dx = \sum_{x \in A} P_X(x)dx = P(X \in A)
 \end{equation}
 
 ### **Continuous case**:
 
 \begin{equation}
-E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1}{x \in A} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
+E[g(X)] = \int_{-\infty}^{\infty} \mathbf{1}\{x \in A\} f_X(x) dx = \int_{x\in A} f_X(x) dx = P(X \in A)
 \end{equation}
 
 
@@ -359,8 +357,8 @@ The chain rule we derived earlier for events can be applied to random variables 
 
 {% math %}
 \begin{aligned}
-&   & p_{X_1, \cdots X_n} (x_1, \cdots, x_n) \\
-& = & p_{X_1} (x_1) p_{X_2 \mid X_1} (x_2 \mid x_1) \cdots p_{X_n \mid X_1, \cdots, X_{n-1}} (x_n \mid x_1, \cdots, x_{n-1})
+  & p_{X_1, \cdots X_n} (x_1, \cdots, x_n) \\
+= & p_{X_1} (x_1) p_{X_2 \mid X_1} (x_2 \mid x_1) \cdots p_{X_n \mid X_1, \cdots, X_{n-1}} (x_n \mid x_1, \cdots, x_{n-1})
 \end{aligned}
 {% endmath %}
 


### PR DESCRIPTION
Split the long equations and fix equations that were not displayed.
