### PR TITLE
Clarify I-Maps

### DIFF
--- a/representation/directed/index.md
+++ b/representation/directed/index.md
@@ -70,7 +70,7 @@ By expressing a probability in this form, we are introducing into our model assu
 This raises the question: which independence assumptions are we exactly making by using a model Bayesian network with a given structure described by $$G$$?
 This question is important for two reasons: we should know precisely what model assumptions we are making (and whether they are correct); also, this information will help us design more efficient inference algorithms later on.
 
-Let us use the notation $$I(p)$$ to denote the set of all conditional independencies that hold for a joint distribution $$p$$. For example, if $$p(x,y)=p(x)p(y)$$, then we say that $$x \perp y \in I(p)$$.
+Let us use the notation $$I(p)$$ to denote the set of all independencies that hold for a joint distribution $$p$$. For example, if $$p(x,y)=p(x)p(y)$$, then we say that $$x \perp y \in I(p)$$.
 
 ### Independencies described by directed graphs
 


### PR DESCRIPTION
Used to say, "Let I(p) denote the set of all CONDITIONAL independencies that hold for a distribution p" but the example given is just a regular ol' independence rather than an explicit conditional independence. So I changed it to say "the set of all independencies" which aligns with the example and with the PGM textbook.