### PR TITLE
Fix 2.5 variance example typo fx to fX

### DIFF
--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -193,7 +193,7 @@ constant with respect to the outer expectation.
 
 **Example** Calculate the mean and the variance of the uniform random variable $$X$$ with PDF $$f_X(x) = 1, ∀x  \in  [0, 1], 0$$ elsewhere.
 
-- $$E[X] = \int^{\infty}_{-\infty} x f_x(x) dx = \int^1_0 x dx = \frac{1}{2}$$
+- $$E[X] = \int^{\infty}_{-\infty} x f_X(x) dx = \int^1_0 x dx = \frac{1}{2}$$
 
 - $$E[X^2] = \int^{\infty}_{-\infty} x^2 f_X(x)dx = \int^1_0 x^2 dx = \frac{1}{3}$$
 


### PR DESCRIPTION
Corrected Erratum in 2.5 Variance example, in the E[X] formula where fx should be fX