### PR TITLE
Corrected equation for sum-product message passing

### DIFF
--- a/inference/jt/index.md
+++ b/inference/jt/index.md
@@ -47,7 +47,7 @@ Again, observe that this message is precisely the factor $$\tau$$ that $$x_i$$ w
 
 Because of this observation, after we have computed all messages, we may answer any marginal query over $$x_i$$ in constant time using the equation
 
-$$ p(x_i) = \prod_{\ell \in N(i)} m_{\ell \to i}(x_i). $$
+$$ p(x_i) = \phi(x_i) \prod_{\ell \in N(i)} m_{\ell \to i}(x_i). $$
 
 ### Sum-product message passing for factor trees
 


### PR DESCRIPTION
I think that the equation on line 50 in the BP and JT notes is missing a factor of $$\phi(x_i)$$. Since local single node potentials are included in the messages sent from $$x_k$$ to $$x_j$$ in the preceding equation, shouldn't we consider the local single node potential at node $$x_i$$ when computing its marginal?