### PR TITLE
Fix typos in JT and VE inference

### DIFF
--- a/inference/jt/index.md
+++ b/inference/jt/index.md
@@ -62,7 +62,7 @@ Both messages require taking a product, but only the factor-to-variable messages
 $$
 \nu_{var(i)\to fac(s)}(x_i) = \prod_{t\in\mathcal N(i)\setminus s}\mu_{fac(t)\to var(i)}(x_i) \\
 
-\mu_{fac(s)\to var(i)}(x_i) = \sum_{x_{\mathcal N(s)\setminus i}}f_s(x_{\mathcal N(s)})\prod_{j\in\mathcal N(i)\setminus i}\nu_{var(j)\to fac(s)}(x_j)
+\mu_{fac(s)\to var(i)}(x_i) = \sum_{x_{\mathcal N(s)\setminus i}}f_s(x_{\mathcal N(s)})\prod_{j\in\mathcal N(s)\setminus i}\nu_{var(j)\to fac(s)}(x_j)
 $$
 
 So now the algorithm proceeds in the same way as above: as long as there is a factor or variable ready to transmit to a variable or factor, respectively, send the appropriate factor-to-variable or variable-to-factor message as defined above.

--- a/inference/jt/index.md
+++ b/inference/jt/index.md
@@ -47,7 +47,7 @@ Again, observe that this message is precisely the factor $$\tau$$ that $$x_i$$ w
 
 Because of this observation, after we have computed all messages, we may answer any marginal query over $$x_i$$ in constant time using the equation
 
-$$ p(x_i) = \phi(x_i) \prod_{\ell \in N(i)} m_{\ell \to i}(x_i). $$
+$$ p(x_i) \propto \phi(x_i) \prod_{\ell \in N(i)} m_{\ell \to i}(x_i). $$
 
 ### Sum-product message passing for factor trees
 
@@ -71,7 +71,7 @@ So now the algorithm proceeds in the same way as above: as long as there is a fa
 
 So far, we have said very little about the second type of inference we are interested in performing, which are MAP queries
 
-$$ \max_{x_1, \dots, x_n} p(x_1,...,x_n). $$
+$$ \max_{x_1, \dotsc, x_n} p(x_1, \dotsc, x_n). $$
 
 The framework we have introduced for marginal queries now lets us easily perform MAP queries as well. The key observation to make, is that we can decompose the problem of MAP inference in exactly the same way as we decomposed the marginal inference problem by replacing sums with maxes.
 
@@ -80,18 +80,18 @@ For example, we may compute the partition function of a chain MRF as follows:
 $$
 \begin{align*}
 Z
-& = \sum_{x_1} \cdots \sum_{x_n} \phi(x_1) \prod_{i=2}^n \phi(x_i , x_{i-1}) \\
-& = \sum_{x_n} \sum_{x_{n-1}} \phi(x_n , x_{n-1}) \sum_{x_{n-2}} \phi(x_{n-1} , x_{n-2}) \cdots \sum_{x_1} \phi(x_2 , x_1) \phi(x_1) .
+&= \sum_{x_1} \cdots \sum_{x_n} \phi(x_1) \prod_{i=2}^n \phi(x_i, x_{i-1}) \\
+&= \sum_{x_n} \sum_{x_{n-1}} \phi(x_n, x_{n-1}) \sum_{x_{n-2}} \phi(x_{n-1}, x_{n-2}) \cdots \sum_{x_1} \phi(x_2 , x_1) \phi(x_1) .
 \end{align*}
 $$
 
-To compute the mode $$\tp^*$$ of $$\tp(x_1,...,x_n)$$, we simply replace sums with maxes, i.e.
+To compute the mode $$\tp^*$$ of $$\tp(x_1, \dotsc, x_n)$$, we simply replace sums with maxes, i.e.
 
 $$
 \begin{align*}
 \tp^*
-& = \max_{x_1} \cdots \max_{x_n} \phi(x_1) \prod_{i=2}^n \phi(x_i , x_{i-1}) \\
-& = \max_{x_n} \max_{x_{n-1}} \phi(x_n , x_{n-1}) \max_{x_{n-2}} \phi(x_{n-1} , x_{n-2}) \cdots \max_{x_1} \phi(x_2 , x_1) \phi(x_1) .
+&= \max_{x_1} \cdots \max_{x_n} \phi(x_1) \prod_{i=2}^n \phi(x_i, x_{i-1}) \\
+&= \max_{x_n} \max_{x_{n-1}} \phi(x_n, x_{n-1}) \max_{x_{n-2}} \phi(x_{n-1}, x_{n-2}) \cdots \max_{x_1} \phi(x_2 , x_1) \phi(x_1) .
 \end{align*}
 $$
 
@@ -111,10 +111,10 @@ Before we define the full algorithm, let us first start with an example, like we
 
 Suppose that we are performing marginal inference and that we are given an MRF of the form
 
-$$ p(x_1,..,x_n) = \frac{1}{Z} \prod_{c \in C} \phi_c(x_c), $$
+$$ p(x_1, \dotsc, x_n) = \frac{1}{Z} \prod_{c \in C} \phi_c(x_c), $$
 
-Crucially, we will assume that the cliques $$c$$ have a form of path structure, meaning that we can find an ordering $$x_c^{(1)}, ..., x_c^{(n)}$$ with the property that if $$x_i \in x_c^{(j)}$$ and $$x_i \in x_c^{(k)}$$ for some variable $$x_i$$ then $$x_i \in x_c^{(\ell)}$$ for all $$x_c^{(\ell)}$$ on the path between $$x_c^{(j)}$$ and $$x_c^{(k)}$$. We refer to this assumption as the *running intersection* property (RIP).
-{% include maincolumn_img.html src='assets/img/junctionpath.png' caption='A chain MRF whose cliques are organized into a chain structure. Round nodes represent cliques and the variables in their scope; rectangular nodes indicate sepsets, which are variables forming the intersection of the scopes of two neighboring cliques' %}
+Crucially, we will assume that the cliques $$c$$ have a form of path structure, meaning that we can find an ordering $$x_c^{(1)}, \dotsc, x_c^{(n)}$$ with the property that if $$x_i \in x_c^{(j)}$$ and $$x_i \in x_c^{(k)}$$ for some variable $$x_i$$ then $$x_i \in x_c^{(\ell)}$$ for all $$x_c^{(\ell)}$$ on the path between $$x_c^{(j)}$$ and $$x_c^{(k)}$$. We refer to this assumption as the *running intersection* property (RIP).
+{% include maincolumn_img.html src='assets/img/junctionpath.png' caption='A chain MRF whose cliques are organized into a chain structure. Round nodes represent cliques and the variables in their scope; rectangular nodes indicate sepsets, which are variables forming the intersection of the scopes of two neighboring cliques.' %}
 
 Suppose that we are interested in computing the marginal probability $$p(x_1)$$ in the above example. Given our assumptions, we may again use a form of variable elimination to "push in" certain variables deeper into the product of cluster potentials:
 
@@ -155,7 +155,7 @@ Let us now define the junction tree algorithm, and then explain why it works. At
 
 More precisely, let us define the potential $$\psi_c(x_c)$$ of each cluster $$c$$ as the product of all the factors $$\phi$$ in $$G$$ that have been assigned to $$c$$. By the family preservation property, this is well-defined, and we may assume that our distribution is in the form
 
-$$ p(x_1,..,x_n) = \frac{1}{Z} \prod_{c \in C} \psi_c(x_c). $$
+$$ p(x_1, \dotsc, x_n) = \frac{1}{Z} \prod_{c \in C} \psi_c(x_c). $$
 
 Then, at each step of the algorithm, we choose a pair of adjacent clusters $$c^{(i)}, c^{(j)}$$ in $$T$$ and compute a message whose scope is the sepset $$S_{ij}$$ between the two clusters:
 

--- a/inference/ve/index.md
+++ b/inference/ve/index.md
@@ -59,7 +59,7 @@ Having established some intuitions, with a special case, we will now introduce t
 
 We will assume that we are given a graphical model as a product of factors
 
-$$ p(x_1,..,x_n) = \prod_{c \in C} \phi_c(x_c). $$
+$$ p(x_1, \dotsc, x_n) = \prod_{c \in C} \phi_c(x_c). $$
 
 Recall that we can view a factor as a multi-dimensional table assigning a value to each assignment of a set of variables $$x_c$$. In the context of a Bayesian network, the factors correspond to conditional probability distributions; however, this definition also makes our algorithm equally applicable to Markov Random Fields. In this latter case, the factors encode an unnormalized distribution; to compute marginals, we first calculate the partition function (also using variable elimination), then we compute marginals using the unnormalized distribution, and finally we divide the result by the partition constant to construct a valid marginal probability.
 

--- a/inference/ve/index.md
+++ b/inference/ve/index.md
@@ -41,7 +41,7 @@ p(x_n)
 \end{align*}
 $$
 
-We perform this summation by first summing the inner terms, starting from $$x_1$$, and ending with $$x_{n-1}$$. More concretely, we start by computing an intermediary *factor* $$\tau(x_2) = \sum_{x_1} p(x_2 \mid x_1) p(x_1)$$ by summing out $$x_1$$. This takes $$O(d^2)$$ time because we must sum over $$x_1$$ for each assignment to $$x_2$$. The resulting factor $$\tau(x_2)$$ can be thought of as a table of values (though not necessarily probabilities), with one entry for each assignment to $$x_2$$ (just as factor $$p(x_1)$$ can be represented as a table. We may then rewrite the marginal probability using $$\tau$$ as
+We sum the inner terms first, starting from $$x_1$$ and ending with $$x_{n-1}$$. Concretely, we start by computing an intermediary *factor* $$\tau(x_2) = \sum_{x_1} p(x_2 \mid x_1) p(x_1)$$ by summing out $$x_1$$. This takes $$O(d^2)$$ time because we must sum over $$x_1$$ for each assignment to $$x_2$$. The resulting factor $$\tau(x_2)$$ can be thought of as a table of $$d$$ values (though not necessarily probabilities), with one entry for each assignment to $$x_2$$ (just as factor $$p(x_1)$$ can be represented as a table). We may then rewrite the marginal probability using $$\tau$$ as
 
 $$
 p(x_n) = \sum_{x_{n-1}} p(x_n \mid x_{n-1}) \sum_{x_{n-2}} p(x_{n-1} \mid x_{n-2}) \cdots \sum_{x_2} p(x_3 \mid x_2) \tau(x_2).
@@ -53,7 +53,7 @@ Also, at each time, we are *eliminating* a variable, which gives the algorithm i
 
 ## Eliminating Variables
 
-Having established some intuitions, with a special case, we will now introduce the variable elimination algorithm in its most general form.
+Having established some intuitions, with a special case, we now introduce the variable elimination algorithm in its general form.
 
 ### Factors
 
@@ -136,9 +136,9 @@ To compute $$P(Y, E = e)$$, we simply take every factor $$\phi(X', Y', E')$$ whi
 
 It is very important to understand that the running time of Variable Elimination depends heavily on the structure of the graph.
 
-In the previous example, suppose we eliminated $$g$$ first. Then, we would have had to transform the factors $$p(g \mid i, d), \phi(l \mid g)$$ into a big factor $$\tau(d, i, l)$$ over 3 variables, which would require $$O(d^4)$$ time to compute. If we had a factor $$S \rightarrow G$$, then we would have had to eliminate $$p(g \mid s)$$ as well, producing a single giant factor $$\tau(d, i, l, s)$$ in $$O(d^5)$$ time. Then, eliminating any variable from this factor would require almost as much work as if we had started with the original distribution, since all the variable have become coupled.
+In the previous example, suppose we eliminated $$g$$ first. Then, we would have had to transform the factors $$p(g \mid i, d), \phi(l \mid g)$$ into a big factor $$\tau(d, i, l)$$ over 3 variables, which would require $$O(d^4)$$ time to compute. If we had a factor $$S \rightarrow G$$, then we would have had to eliminate $$p(g \mid s)$$ as well, producing a single giant factor $$\tau(d, i, l, s)$$ in $$O(d^5)$$ time. Then, eliminating any variable from this factor would require almost as much work as if we had started with the original distribution, since all the variables have become coupled.
 
-Clearly some ordering are much more efficient than others. In fact, the running time of Variable Elimination will equal $$O(m d^M)$$, where $$M$$ is the maximum size of any factor during the elimination process and $$m$$ is the number of variables.
+Clearly some orderings are more efficient than others. In fact, the running time of Variable Elimination is $$O(m d^M)$$, where $$M$$ is the maximum size of any factor during the elimination process and $$m$$ is the number of variables.
 
 ### Choosing variable elimination orderings
 
@@ -148,7 +148,7 @@ Unfortunately, choosing the optimal VE ordering is an NP-hard problem. However, 
 - *Min-weight*: Choose variables to minimize the product of the cardinalities of its dependent variables.
 - *Min-fill*: Choose vertices to minimize the size of the factor that will be added to the graph.
 
-In practice, these methods often result in reasonably good performance in many interesting settings.
+These methods often result in reasonably good performance in many interesting settings.
 
 
 <br/>

--- a/learning/undirected/index.md
+++ b/learning/undirected/index.md
@@ -10,18 +10,18 @@ Let us now look at parameter learning in undirected graphical models. Unfortunat
 Let us start with a Markov random field (MRF) of the form
 
 $$
-p(x_1,..,x_n) = \frac{1}{Z(\varphi)} \prod_{c \in C} \phi_c(x_c; \varphi),
+p(x_1, \dotsc, x_n) = \frac{1}{Z(\varphi)} \prod_{c \in C} \phi_c(x_c; \varphi),
 $$
 
 where
 
-$$ Z(\varphi) = \sum_{x_1,..,x_n}\prod_{c \in C} \phi_c(x_c; \varphi) $$
+$$ Z(\varphi) = \sum_{x_1, \dotsc, x_n}\prod_{c \in C} \phi_c(x_c; \varphi) $$
 
 is the normalizing constant. We can reparametrize $$p$$ as follows:
 
 $$
 \begin{align*}
-p(x_1,..,x_n)
+p(x_1, \dotsc, x_n)
 & = \frac{1}{Z(\varphi)} \exp\left( \sum_{c \in C} \log\phi_c(x_c; \varphi) \right) \\
 & = \frac{1}{Z(\varphi)} \exp\left( \sum_{c \in C} \sum_{x'_c} 1\{x'_c = x_c\} \log\phi_c(x'_c; \varphi) \right) \\
 & = \frac{\exp(\theta^T f(x))}{Z(\theta)},
@@ -157,7 +157,7 @@ $$
 where
 
 $$
-Z(x, \varphi) = \sum_{y_1,..,y_n}\prod_{c \in C} \phi_c(y_c, x; \varphi)
+Z(x, \varphi) = \sum_{y_1, \dotsc, y_n}\prod_{c \in C} \phi_c(y_c, x; \varphi)
 $$
 
 is the partition function. The feature functions now depend on $$x$$ in addition to $$y$$. The $$x$$ variables are fixed and the distribution is only over $$y$$; the partition function is thus a function of both $$x$$ and $$\varphi$$.

--- a/representation/undirected/index.md
+++ b/representation/undirected/index.md
@@ -43,11 +43,11 @@ Note that unlike in the directed case, we are not saying anything about how one 
 
 A Markov Random Field (MRF) is a probability distribution $$p$$ over variables $$x_1,...,x_n$$ defined by an *undirected* graph $$G$$ in which nodes correspond to variables $$x_i$$. The probability $$p$$ has the form
 
-$$ p(x_1,..,x_n) = \frac{1}{Z} \prod_{c \in C} \phi_c(x_c), $$
+$$ p(x_1, \dotsc, x_n) = \frac{1}{Z} \prod_{c \in C} \phi_c(x_c), $$
 
 where $$C$$ denotes the set of *cliques* (i.e. fully connected subgraphs) of $$G$$. The value
 
-$$ Z = \sum_{x_1,..,x_n} \prod_{c \in C} \phi_c(x_c) $$
+$$ Z = \sum_{x_1, \dotsc, x_n} \prod_{c \in C} \phi_c(x_c) $$
 
 is a normalizing constant that ensures that the distribution sums to one.
 


### PR DESCRIPTION
1) Single-variable marginals are proportional to (not equal to) product of messages. This is because the product of unnormalized factors is still unnormalized.
2) Fix other typos in JT and VE inference.

Also fixed some typos (replacing `..` and `...` with `\dotsc`)