### PR TITLE
Update running time of VE

### DIFF
--- a/inference/ve/index.md
+++ b/inference/ve/index.md
@@ -138,7 +138,7 @@ It is very important to understand that the running time of Variable Elimination
 
 In the previous example, suppose we eliminated $$g$$ first. Then, we would have had to transform the factors $$p(g \mid i, d), \phi(l \mid g)$$ into a big factor $$\tau(d, i, l)$$ over 3 variables, which would require $$O(d^4)$$ time to compute. If we had a factor $$S \rightarrow G$$, then we would have had to eliminate $$p(g \mid s)$$ as well, producing a single giant factor $$\tau(d, i, l, s)$$ in $$O(d^5)$$ time. Then, eliminating any variable from this factor would require almost as much work as if we had started with the original distribution, since all the variables have become coupled.
 
-Clearly some ordering are more efficient than others. In fact, the running time of Variable Elimination is $$O(m d^{M+1})$$, where $$M$$ is the maximium size of any factor $$\tau$$ formed during the elimination process and $$m$$ is the number of variables.
+Clearly some orderings are more efficient than others. In fact, the running time of Variable Elimination is $$O(m d^{M+1})$$, where $$M$$ is the maximum size of any factor $$\tau$$ formed during the elimination process and $$m$$ is the number of variables.
 
 ### Choosing variable elimination orderings
 

--- a/inference/ve/index.md
+++ b/inference/ve/index.md
@@ -138,7 +138,7 @@ It is very important to understand that the running time of Variable Elimination
 
 In the previous example, suppose we eliminated $$g$$ first. Then, we would have had to transform the factors $$p(g \mid i, d), \phi(l \mid g)$$ into a big factor $$\tau(d, i, l)$$ over 3 variables, which would require $$O(d^4)$$ time to compute. If we had a factor $$S \rightarrow G$$, then we would have had to eliminate $$p(g \mid s)$$ as well, producing a single giant factor $$\tau(d, i, l, s)$$ in $$O(d^5)$$ time. Then, eliminating any variable from this factor would require almost as much work as if we had started with the original distribution, since all the variables have become coupled.
 
-Clearly some orderings are more efficient than others. In fact, the running time of Variable Elimination is $$O(m d^M)$$, where $$M$$ is the maximum size of any factor during the elimination process and $$m$$ is the number of variables.
+Clearly some ordering are more efficient than others. In fact, the running time of Variable Elimination is $$O(m d^{M+1})$$, where $$M$$ is the maximium size of any factor $$\tau$$ formed during the elimination process and $$m$$ is the number of variables.
 
 ### Choosing variable elimination orderings
 


### PR DESCRIPTION
In the section on Running Time of Variable Elimination, I interpret "size of any factor during the elimination process" as the size of a factor $$\tau$$ formed during the elimination process. My interpretation seems to agree with the discussion where it is stated "...a big factor $$\tau(d,i,l)$$ over 3 variables, which would require $$O(d^4)$$ time to compute." 
In this case, the running time should be depend on $$d{M+1})$$ instead of $$d^M$ since one variable was eliminated and there are $$M$$ variables in the factor $$\tau$$. I've edited the discussion to make this clear.