### PR TITLE
Typo correction -- propto to equal, Asymptotically unbiased definition corrected in Sampling, MCMC alg fixed in Sampling

### DIFF
--- a/inference/jt/index.md
+++ b/inference/jt/index.md
@@ -170,7 +170,7 @@ $$
 These updates are often referred to as *Shafer-Shenoy*. After all the messages have been passed, beliefs will be proportional to the marginal probabilities over their scopes, i.e. $$\beta_c(x_c) \propto p(x_c)$$. We may answer queries of the form $$\tp(x)$$ for $$x \in x_c$$ by marginalizing out the variable in its belief{% include sidenote.html id="note-dp" note="Readers familiar with combinatorial optimization will recognize this as a special case of dynamic programming on a tree decomposition of a graph with bounded treewidth." %}
 
 $$
-\tp(x) \propto \sum_{x_c \backslash x} \beta_c(x_c).
+\tp(x) = \sum_{x_c \backslash x} \beta_c(x_c).
 $$
 
 To get the actual (normalized) probability, we divide by the partition function $$Z$$ which is computed by summing all the beliefs in a cluster, $$Z = \sum_{x_c} \beta_c(x_c)$$.

--- a/inference/sampling/index.md
+++ b/inference/sampling/index.md
@@ -218,7 +218,7 @@ As we said, the idea of MCMC algorithms is to construct a Markov chain over the 
 At a high level, MCMC algorithms will have the following structure. They take as argument a transition operator $$T$$ specifying a Markov chain whose stationary distribution is $$p$$, and an initial assignment $$x_0$$ to the variables of $$p$$. An MCMC algorithm then perform the following steps.
 
 1. Run the Markov chain from $$x_0$$ for $$B$$ *burn-in* steps.
-2. Run the Markov chain from $$x_0$$ for $$N$$ *sampling* steps and collect all the states that it visits.
+2. Run the Markov chain for $$N$$ *sampling* steps and collect all the states that it visits.
 
 Assuming $$B$$ is sufficiently large, the latter collection of states will form samples from $$p$$. We may then use these samples for Monte Carlo integration (or in importance sampling). We may also use them to produce Monte Carlo estimates of marginal probabilities. Finally, we may take the sample with the highest probability and use it as an estimate of the mode (i.e. perform MAP inference).
 

--- a/inference/sampling/index.md
+++ b/inference/sampling/index.md
@@ -146,12 +146,12 @@ Unfortunately, there is one drawback to the normalized importance sampling estim
 $$
     \E_{z \sim q} [\hat{P}(X_i=x_i \mid E=e)]
     = \E_{z \sim q} [\delta(z)]
-    \neq P(X_i=x_i, E=e)
+    \neq P(X_i=x_i \mid E=e)
 $$
 
 Fortunately, because the numerator and denominator are both unbiased, the normalized importance sampling estimator remains *asymptotically unbiased*, meaning that
 
-$$ \lim_{T \to \infty} \hat{P}(X_i=x_i \mid E=e) = P(X_i=x_i, E=e). $$
+$$ \lim_{T \to \infty} \E_{z \sim q} [\hat{P}(X_i=x_i \mid E=e)] = P(X_i=x_i \mid E=e). $$
 
 
 ## Markov chain Monte Carlo

--- a/learning/directed/index.md
+++ b/learning/directed/index.md
@@ -144,7 +144,7 @@ $$
 Taking logs and combining like terms, this becomes
 
 $$
-\log L(\theta, D) = \sum_{i=1}^n \#(x_i, pa(x_i)) \cdot \log(\theta_{x_i \mid pa(x_i)}).
+\log L(\theta, D) = \sum_{i=1}^n \sum_{pa(x_i)} \sum_{x_i} \#(x_i, pa(x_i)) \cdot \log(\theta_{x_i \mid pa(x_i)}).
 $$
 
 Thus, maximization of the (log) likelihood function decomposes into separate maximizations for the local conditional distributions!


### PR DESCRIPTION
\propto is unnecessary, since p already has a tilde over it, indicating that it is unnormalized. Can be replaced with an equal sign.