### PR TITLE
Fix unnecessary to

### DIFF
--- a/preliminaries/applications/index.md
+++ b/preliminaries/applications/index.md
@@ -31,7 +31,7 @@ Consider a distribution $$p(\bfx)$$ over images, where $$\bfx$$ is an image repr
 <a id="image-generation"></a>
 ### Image Generation
 
-[Radford et al.](https://arxiv.org/abs/1710.10196) trained a probabilistic model $$ p(\bfx) $$ that assigns high probability to images that look like bedrooms. To do so, they trained their model on a dataset of bedroom images, a sample of which is shown below:
+[Radford et al.](https://arxiv.org/abs/1511.06434) trained a probabilistic model $$ p(\bfx) $$ that assigns high probability to images that look like bedrooms. To do so, they trained their model on a dataset of bedroom images, a sample of which is shown below:
 
 **Training Data**<br />
 ![bedroom1](bedroominpainting1.png)

--- a/representation/directed/index.md
+++ b/representation/directed/index.md
@@ -36,7 +36,7 @@ When the variables are discrete (which will be often be the case in the problem 
 
 ### Graphical representation.
 
-Distributions of this form can be naturally expressed as *directed acyclic graphs*, in which vertices correspond to variables $$x_i$$ and edges indicate dependency relationships. In particular we set the parents of each node to $$x_i$$ to its ancestors $$x_{A_i}$$.
+Distributions of this form can be naturally expressed as *directed acyclic graphs*, in which vertices correspond to variables $$x_i$$ and edges indicate dependency relationships. In particular we set the parents of each node $$x_i$$ to its ancestors $$x_{A_i}$$.
 
 As an example, consider a model of a student's grade $$g$$ on an exam. This grade depends on the exam's difficulty $$d$$ and the student's intelligence $$i$$; it also affects the quality $$l$$ of the reference letter from the professor who taught the course. The student's intelligence $$i$$ affects his SAT score $$s$$ in addition to $$g$$. Each variable is binary, except for $$g$$, which takes 3 possible values.{% include marginfigure.html id="nb1" url="assets/img/grade-model.png" description="Bayes net model describing the performance of a student on an exam. The distribution can be represented a product of conditional probability distributions specified by tables. The form of these distributions is described by edges in the graph." %} The joint probability distribution over the 5 variables naturally factorizes as follows:
 


### PR DESCRIPTION
I found an unnecessary word 'to' in the sentence that specifies the construction of DAG in representation/directed.