### PR TITLE
improved grammar/definition of d-separation

### DIFF
--- a/representation/directed/index.md
+++ b/representation/directed/index.md
@@ -38,7 +38,7 @@ When the variables are discrete (which will be often be the case in the problem 
 
 Distributions of this form can be naturally expressed as *directed acyclic graphs*, in which vertices correspond to variables $$x_i$$ and edges indicate dependency relationships. In particular we set the parents of each node $$x_i$$ to its ancestors $$x_{A_i}$$.
 
-As an example, consider a model of a student's grade $$g$$ on an exam. This grade depends on the exam's difficulty $$d$$ and the student's intelligence $$i$$; it also affects the quality $$l$$ of the reference letter from the professor who taught the course. The student's intelligence $$i$$ affects his SAT score $$s$$ in addition to $$g$$. Each variable is binary, except for $$g$$, which takes 3 possible values.{% include marginfigure.html id="nb1" url="assets/img/grade-model.png" description="Bayes net model describing the performance of a student on an exam. The distribution can be represented a product of conditional probability distributions specified by tables. The form of these distributions is described by edges in the graph." %} The joint probability distribution over the 5 variables naturally factorizes as follows:
+As an example, consider a model of a student's grade $$g$$ on an exam. This grade depends on the exam's difficulty $$d$$ and the student's intelligence $$i$$; it also affects the quality $$l$$ of the reference letter from the professor who taught the course. The student's intelligence $$i$$ affects his SAT score $$s$$, as does $$g$$. Each variable is binary, except for $$g$$, which takes 3 possible values.{% include marginfigure.html id="nb1" url="assets/img/grade-model.png" description="Bayes net model describing the performance of a student on an exam. The distribution can be represented a product of conditional probability distributions specified by tables. The form of these distributions is described by edges in the graph." %} The joint probability distribution over the 5 variables naturally factorizes as follows:
 
 $$ p(l, g, i, d, s) = p(l \mid g) p(g \mid i, d) p(i) p(d) p(s \mid i). $$
 
@@ -81,7 +81,7 @@ The latter case requires additional explanation. Suppose that $$C$$ is a Boolean
 
 These structures clearly describe the independencies encoded by a three-variable Bayesian net. We can extend them to general networks by applying them recursively over any larger graph. This leads to a notion called $$d$$-separation (where $$d$$ stands for directed).
 
-We say that $$Q$$, $$W$$ are $$d$$-separated when the set of variables $$O$$ are observed if they are not connected by an *active path*. An undirected path in the Bayesian Network structure $$G$$ is called *active* given observed variables $$O$$ if for every consecutive triple of variables $$X,Y,Z$$ on the path, one of the following holds:
+We say that $$Q$$ and $$W$$ (two subsets of the vertices of $$G$$) are $$d$$-separated, relative to the set of variables $$O$$ that are observed, if $$Q$$ and $$W$$ are not connected by an *active path*. An undirected path in the Bayesian Network structure $$G$$ is called *active* given observed variables $$O$$ if for every consecutive triple of variables $$X,Y,Z$$ on the path, one of the following holds:
 
 - $$X \leftarrow Y \leftarrow Z$$, and $$Y$$ is unobserved $$Y \not\in O$$
 - $$X \rightarrow Y \rightarrow Z$$, and $$Y$$ is unobserved $$Y \not\in O$$


### PR DESCRIPTION
"X affects Y in addition to Z" can mean either "X affects Y and Z" or "X and Z affect Y"; I changed the wording to eliminate this ambiguity.

The definition of d-ambiguity didn't say what Q and W were; I added that they contained vertices from G. "they" was used to refer to Q and W, but the reader could've easily thought that it referred instead to O, the variables that are observed. So I got rid of the ambiguity there, too.