### PR TITLE
Weaken claim about CDF of X

### DIFF
--- a/preliminaries/probabilityreview/index.md
+++ b/preliminaries/probabilityreview/index.md
@@ -92,7 +92,7 @@ In order to specify the probability measures used when dealing with random varia
 
 $$ F_X(x) = P(X \leq x). $$
 
-By using this function, one can calculate the probability of any event.
+By using this function, one can calculate the probability that $$X$$ takes on a value between any two real constants $$a$$ and $$b$$ (where $$a < b$$).
 
 ### **Properties**:
 <!--Figure 1: A cumulative distribution function (CDF).-->


### PR DESCRIPTION
There are some events (sets of outcomes in Omega) that can't be distinguished just by using the CDF on the random variable X. For example, if your X(omega) is "sum of number of heads over 2 (non-independent) coin flips", then you can't use the CDF of X to compute the probability of the event containing the single outcome "first get a head, then get a tails". In this example, you the closest you can get by using the CDF is you can compute the probability of the event containing the two outcomes "first head then tails" and "first tails then heads".