### PR TITLE
Modified inference eqtn in introduction

### DIFF
--- a/preliminaries/introduction/index.md
+++ b/preliminaries/introduction/index.md
@@ -81,7 +81,7 @@ $$ p(x_1) = \sum_{x_2} \sum_{x_3} \cdots \sum_{x_n} p(x_1, x_2, \dotsc, x_n). $$
 
 - *Maximum a posteriori (MAP) inference* asks for the most likely assignment of variables. For example, we may try to determine the most likely spam message, solving the problem
 
-$$ \max_{x_1, \dots, x_n} p(x_1,\dotsc,x_n, y=1). $$
+$$\underset{x_1, \dots, x_n}{\operatorname{argmax}}p(x_1,\dotsc,x_n, y=1).$$
 
 Often our queries will involve evidence (like in the MAP example above), in which case we will fix the assignment of a subset of the variables.
 


### PR DESCRIPTION
From the introduction [here](https://ermongroup.github.io/cs228-notes/preliminaries/introduction/):

![image](https://user-images.githubusercontent.com/22034067/72214867-c5ca7880-34bf-11ea-96de-28445f7c78d1.png)

I've suggested that if we are trying to solve the most likely spam message, then we are trying to find the argmax of the function, and not the max. The suggested eqtn is this:

![image](https://user-images.githubusercontent.com/22034067/72214862-b5b29900-34bf-11ea-958f-5541bb5e3ef0.png)
