### PR TITLE
Update variable elimination web app link with archived version

### DIFF
--- a/inference/ve/index.md
+++ b/inference/ve/index.md
@@ -100,7 +100,7 @@ More formally, for each variable $$X_i$$ (ordered according to $$O$$),
 2. Marginalize out $$X_i$$ to obtain a new factor $$\tau$$
 3. Replace the factors $$\Phi_i$$ with $$\tau$$
 
-A former CS228 student has created an [interactive web simulation](http://pgmlearning.herokuapp.com/vElimApp) for visualizing the variable elimination algorithm. Feel free to play around with it and, if you do, please submit any feedback or bugs through the Feedback button on the web app.
+A former CS228 student has created an [interactive web simulation](https://web.archive.org/web/20221024031253/https://pgmlearning.herokuapp.com/vElimApp) for visualizing the variable elimination algorithm. Feel free to play around with it and, if you do, please submit any feedback or bugs through the Feedback button on the web app.
 
 ### Examples
 


### PR DESCRIPTION
The link in the notes was broken for me but the archive.org version seems to still be running